### PR TITLE
Fix incorrect property for col-span-* utility

### DIFF
--- a/plugins/css-grid/index.js
+++ b/plugins/css-grid/index.js
@@ -15,7 +15,7 @@ module.exports = function ({ grids = _.range(1, 12), gaps = {}, variants = ['res
       })),
       ..._.range(1, _.max(grids) + 1).map(span => ({
         [`.col-span-${span}`]: {
-          gridColumnStart: `span ${span}`,
+          gridColumn: `span ${span}`,
         }
       })),
       ..._.range(1, _.max(grids) + 2).map(line => ({


### PR DESCRIPTION
I believe the `col-span-*` utilities were intended to be used for spanning the given columns which means `gridColumn` would be the correct property to use. It's the utilities on the next lines down (`col-start-*` and `col-end-*`) that should be using `gridColumnStart`/`gridColumnEnd`.